### PR TITLE
54 complete migration to bootstrap v5

### DIFF
--- a/src/main/resources/static/css/customization.css
+++ b/src/main/resources/static/css/customization.css
@@ -7,6 +7,10 @@ body .login-form {
     padding-top: 40px;
 }
 
+.bg-navbar {
+    background-color: #343a40;
+}
+
 .amqp-message .amqp-message-content > .row > div {
     border-bottom: 1px solid #e0e0e0;
     padding: 5px 15px;

--- a/src/main/resources/static/css/customization.css
+++ b/src/main/resources/static/css/customization.css
@@ -11,6 +11,12 @@ body .login-form {
     background-color: #343a40;
 }
 
+.table-queues {
+    border-color: #dee2e6;
+    background-color: #e9ecef;
+    color: #495057;
+}
+
 .amqp-message .amqp-message-content > .row > div {
     border-bottom: 1px solid #e0e0e0;
     padding: 5px 15px;

--- a/src/main/resources/templates/fragments/navbar.html
+++ b/src/main/resources/templates/fragments/navbar.html
@@ -2,14 +2,14 @@
     <div class="container-fluid">
         <span class="navbar-brand"><img alt="RabbitMQ Icon" th:src="@{/gfx/rmq.png}" width="24px" height="24px" style="display: inline-block"/>&nbsp;RabbitMQ :: Queue Management</span>
 
-        <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>
         </button>
     
         <div class="collapse navbar-collapse" id="navbarSupportedContent">
             <ul class="navbar-nav me-auto">
                 <li class="nav-item">
-                    <a class="nav-link" th:href="@{/}"><i class="oi oi-random" aria-hidden="true"></i>&nbsp;Queues</a>
+                    <a class="nav-link" th:href="@{/}"><i class="oi oi-random" aria-hidden="false"></i>&nbsp;Queues</a>
                 </li>
             </ul>
         </div>

--- a/src/main/resources/templates/fragments/navbar.html
+++ b/src/main/resources/templates/fragments/navbar.html
@@ -1,21 +1,23 @@
-<nav th:fragment="navigation-bar-fragment" class="navbar navbar-default navbar-expand-lg navbar-expand-m navbar-fixed-top navbar-dark bg-dark">
-    <span class="navbar-brand"><img alt="RabbitMQ Icon" th:src="@{/gfx/rmq.png}" width="24px" height="24px" style="display: inline-block"/>&nbsp;RabbitMQ :: Queue Management</span>
+<nav th:fragment="navigation-bar-fragment" class="navbar navbar-expand-lg navbar-expand-m navbar-fixed-top navbar-dark bg-navbar">
+    <div class="container-fluid">
+        <span class="navbar-brand"><img alt="RabbitMQ Icon" th:src="@{/gfx/rmq.png}" width="24px" height="24px" style="display: inline-block"/>&nbsp;RabbitMQ :: Queue Management</span>
 
-    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-        <span class="navbar-toggler-icon"></span>
-    </button>
-
-    <div class="collapse navbar-collapse" id="navbarSupportedContent">
-        <ul class="navbar-nav mr-auto">
-            <li class="nav-item">
-                <a class="nav-link" th:href="@{/}"><i class="oi oi-random" aria-hidden="true"></i>&nbsp;Queues</a>
-            </li>
-        </ul>
+        <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+    
+        <div class="collapse navbar-collapse" id="navbarSupportedContent">
+            <ul class="navbar-nav me-auto">
+                <li class="nav-item">
+                    <a class="nav-link" th:href="@{/}"><i class="oi oi-random" aria-hidden="true"></i>&nbsp;Queues</a>
+                </li>
+            </ul>
+        </div>
+    
+        <span sec:authorize="isAuthenticated()" class="navbar-text pr-3" sec:authentication="name"></span>
+    
+        <form sec:authorize="isAuthenticated()" class="form-inline navbar-text" th:action="@{/logout}" method="POST">
+            <button type="submit" class="btn btn-outline-light"><i class="oi oi-power-standby"></i></button>
+        </form>
     </div>
-
-    <span sec:authorize="isAuthenticated()" class="navbar-text pr-3" sec:authentication="name"></span>
-
-    <form sec:authorize="isAuthenticated()" class="form-inline navbar-text" th:action="@{/logout}" method="POST">
-        <button type="submit" class="btn btn-outline-light"><i class="oi oi-power-standby"></i></button>
-    </form>
 </nav>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -23,7 +23,7 @@
 				<strong>Warning!</strong> No queues are available. Check your configuration
 			</div>
 			<table th:if="${not #lists.isEmpty(queues)}" class="table table-bordered table-sm mt-4">
-				<thead class="thead-light">
+				<thead class="table-queues">
 				<tr>
 					<th rowspan="2">Vhost</th>
 					<th rowspan="2">Name</th>
@@ -41,16 +41,16 @@
 				<tbody>
 				<tr th:each="queue : ${queues}">
 					<td th:text="${queue.vhost}"></td>
-					<td><a th:href="@{/messages(queue=${queue.name},vhost=${queue.vhost})}" th:text="${queue.name}">}</a></td>
+					<td><a th:href="@{/messages(queue=${queue.name},vhost=${queue.vhost})}" th:text="${queue.name}" class="text-decoration-none">}</a></td>
 					<td th:text="${queue.state}"></td>
 					<td th:text="${queue.consumers}"></td>
 					<td th:text="${queue.messages}"></td>
 					<td th:text="${queue.messagesReady}"></td>
 					<td th:text="${queue.messagesUnacknowledged}"></td>
 					<td>
-						<span th:if="${queue.durable}" class="badge badge-success">D</span>
-						<span th:if="${queue.isDeadLetterExchangeConfigured()}" class="badge badge-secondary">DLX</span>
-						<span th:if="${queue.isDeadLetterRoutingKeyConfigured()}" class="badge badge-secondary">DLK</span>
+						<span th:if="${queue.durable}" class="badge bg-success">D</span>
+						<span th:if="${queue.isDeadLetterExchangeConfigured()}" class="badge bg-secondary">DLX</span>
+						<span th:if="${queue.isDeadLetterRoutingKeyConfigured()}" class="badge bg-secondary">DLK</span>
 					</td>
 				</tr>
 				</tbody>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -58,5 +58,6 @@
 		</div>
 	</div>
 </div>
+<script th:src="@{/webjars/bootstrap/5.2.0/dist/js/bootstrap.min.js}"></script>
 </body>
 </html>

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -13,12 +13,14 @@
 </head>
 
 <body class="bg-light">
-<nav class="navbar navbar-default navbar-expand-lg navbar-expand-m navbar-fixed-top navbar-dark bg-dark">
-	<span class="navbar-brand"><img alt="RabbitMQ Icon" src="@{/gfx/rmq.png}" width="24px" height="24px" style="display: inline-block"/>&nbsp;RabbitMQ :: Queue Management</span>
+<nav class="navbar navbar-expand-lg navbar-expand-m navbar-fixed-top navbar-dark bg-navbar">
+	<div class="container-fluid">
+		<span class="navbar-brand"><img alt="RabbitMQ Icon" th:src="@{/gfx/rmq.png}" width="24px" height="24px" style="display: inline-block"/>&nbsp;RabbitMQ :: Queue Management</span>
+	</div>
 </nav>
 
 <main class="login-form">
-	<div class="cotainer">
+	<div class="container">
 		<div class="row justify-content-center">
 			<div class="col-md-8">
 				<div class="card">
@@ -30,15 +32,15 @@
 								<span th:text="${login_error_msg}">Invalid username or password</span>
 							</div>
 
-							<div class="form-group row">
-								<label for="username" class="col-md-4 col-form-label text-md-right">Username</label>
+							<div class="form-group row mb-3">
+								<label for="username" class="col-md-4 col-form-label text-md-right mb-2">Username</label>
 								<div class="col-md-6">
 									<input type="text" id="username" class="form-control" name="username" required autofocus>
 								</div>
 							</div>
 
-							<div class="form-group row">
-								<label for="password" class="col-md-4 col-form-label text-md-right">Password</label>
+							<div class="form-group row mb-3">
+								<label for="password" class="col-md-4 col-form-label text-md-right mb-2">Password</label>
 								<div class="col-md-6">
 									<input type="password" id="password" class="form-control" name="password" required>
 								</div>

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -3,7 +3,7 @@
 <head>
 	<link rel="stylesheet" th:href="@{/webjars/open-iconic/1.1.1/font/css/open-iconic-bootstrap.min.css}"/>
 	<link rel="stylesheet" th:href="@{/css/customization.css}"/>
-	<link rel="stylesheet" th:href="@{/webjars/bootstrap/4.6.0/dist/css/bootstrap.min.css}"/>
+	<link rel="stylesheet" th:href="@{/webjars/bootstrap/5.2.0/dist/css/bootstrap.min.css}"/>
 
 	<title>RabbitMQ :: Queue Management</title>
 

--- a/src/main/resources/templates/messages-delete-all.html
+++ b/src/main/resources/templates/messages-delete-all.html
@@ -38,5 +38,6 @@
 		</div>
 	</div>
 </div>
+<script th:src="@{/webjars/bootstrap/5.2.0/dist/js/bootstrap.min.js}"></script>
 </body>
 </html>

--- a/src/main/resources/templates/messages-delete-all.html
+++ b/src/main/resources/templates/messages-delete-all.html
@@ -17,13 +17,13 @@
 <div class="container main">
 	<div class="row">
 		<div class="col-12 mb-4">
-			<h1><span class="text-secondary">Queue</span>&nbsp;<span th:text="${queue}"></span><span class="text-secondary">| Virtual host</span>&nbsp;<span th:text="${vhost}"></span></h1>
+			<h1><span class="text-secondary">Queue</span>&nbsp;<span th:text="${queue}"></span><span class="text-secondary"> | Virtual host</span>&nbsp;<span th:text="${vhost}"></span></h1>
 			<div class="alert alert-danger" role="alert" th:if="${errorMessage != null}">
 				<p class="mb-0"><b><i class="oi oi-warning"></i>&nbsp;Error:</b>&nbsp;<span th:text="${errorMessage}"></span></p>
 			</div>
 
 			<div class="alert alert-danger" role="alert">
-				<h4 class="alert-heading">Delete All Messages:</h4>
+				<h4 class="alert-heading">Delete all messages:</h4>
 				<p>Do you really want to delete all messages in queue <b th:text="${queue}"></b>?</p>
 				<hr>
 				<form class="form-inline" th:action="@{/messages/delete-all}" method="post">

--- a/src/main/resources/templates/messages-delete-all.html
+++ b/src/main/resources/templates/messages-delete-all.html
@@ -3,7 +3,7 @@
 <head>
 	<link rel="stylesheet" th:href="@{/webjars/open-iconic/1.1.1/font/css/open-iconic-bootstrap.min.css}"/>
 	<link rel="stylesheet" th:href="@{/css/customization.css}"/>
-	<link rel="stylesheet" th:href="@{/webjars/bootstrap/4.6.0/dist/css/bootstrap.min.css}"/>
+	<link rel="stylesheet" th:href="@{/webjars/bootstrap/5.2.0/dist/css/bootstrap.min.css}"/>
 
 	<title>RabbitMQ :: Queue Management</title>
 

--- a/src/main/resources/templates/messages-delete-first.html
+++ b/src/main/resources/templates/messages-delete-first.html
@@ -41,5 +41,6 @@
 		</div>
 	</div>
 </div>
+<script th:src="@{/webjars/bootstrap/5.2.0/dist/js/bootstrap.min.js}"></script>
 </body>
 </html>

--- a/src/main/resources/templates/messages-delete-first.html
+++ b/src/main/resources/templates/messages-delete-first.html
@@ -17,13 +17,13 @@
 <div class="container main">
 	<div class="row">
 		<div class="col-12 mb-4">
-			<h1><span class="text-secondary">Queue</span>&nbsp;<span th:text="${queue}"></span><span class="text-secondary">| Virtual host</span>&nbsp;<span th:text="${vhost}"></span></h1>
+			<h1><span class="text-secondary">Queue</span>&nbsp;<span th:text="${queue}"></span><span class="text-secondary"> | Virtual host</span>&nbsp;<span th:text="${vhost}"></span></h1>
 			<div class="alert alert-danger" role="alert" th:if="${errorMessage != null}">
 				<p class="mb-0"><b><i class="oi oi-warning"></i>&nbsp;Error:</b>&nbsp;<span th:text="${errorMessage}"></span></p>
 			</div>
 
 			<div class="alert alert-danger" role="alert">
-				<h4 class="alert-heading">Delete First Messages:</h4>
+				<h4 class="alert-heading">Delete first message:</h4>
 				<p>Do you really want to delete the first message message in queue <b th:text="${queue}"></b> with the following checksum?</p>
 				<p><b>Checksum:</b></p>
 				<pre th:text="${checksum}"></pre>

--- a/src/main/resources/templates/messages-delete-first.html
+++ b/src/main/resources/templates/messages-delete-first.html
@@ -3,7 +3,7 @@
 <head>
 	<link rel="stylesheet" th:href="@{/webjars/open-iconic/1.1.1/font/css/open-iconic-bootstrap.min.css}"/>
 	<link rel="stylesheet" th:href="@{/css/customization.css}"/>
-	<link rel="stylesheet" th:href="@{/webjars/bootstrap/4.6.0/dist/css/bootstrap.min.css}"/>
+	<link rel="stylesheet" th:href="@{/webjars/bootstrap/5.2.0/dist/css/bootstrap.min.css}"/>
 
 	<title>RabbitMQ :: Queue Management</title>
 

--- a/src/main/resources/templates/messages-move-all.html
+++ b/src/main/resources/templates/messages-move-all.html
@@ -17,11 +17,11 @@
 <div class="container main">
 	<div class="row">
 		<div class="col-12 mb-4">
-			<h1><span class="text-secondary">Queue</span>&nbsp;<span th:text="${queue}"></span><span class="text-secondary">| Virtual host</span>&nbsp;<span th:text="${vhost}"></span></h1>
+			<h1><span class="text-secondary">Queue</span>&nbsp;<span th:text="${queue}"></span><span class="text-secondary"> | Virtual host</span>&nbsp;<span th:text="${vhost}"></span></h1>
 
 			<div class="card">
 				<div class="card-body">
-					<h4 class="card-title">Move all Messages</h4>
+					<h4 class="card-title">Move all messages</h4>
 
 					<div class="alert alert-danger" role="alert" th:if="${errorMessage != null}">
 						<p class="mb-0"><b><i class="oi oi-warning"></i>&nbsp;Error:</b>&nbsp;<span th:text="${errorMessage}"></span></p>
@@ -32,8 +32,8 @@
 						<h5>Step 1/2 - Select Target Exchange</h5>
 						<input type="hidden" name="vhost" th:value="${vhost}" />
 						<input type="hidden" name="queue" th:value="${queue}" />
-						<div class="form-group">
-							<label for="targetExchangeSelect">Target Exchange:</label>
+						<div class="form-group mb-3">
+							<label for="targetExchangeSelect" class="mb-2">Target Exchange:</label>
 							<select  class="form-control" id="targetExchangeSelect" name="targetExchange">
 								<option th:each="e : ${exchanges}" th:value="${e.name}" th:text="${e.name}"></option>
 							</select>
@@ -48,12 +48,12 @@
 						<input type="hidden" name="vhost" th:value="${vhost}" />
 						<input type="hidden" name="queue" th:value="${queue}" />
 						<input type="hidden" name="targetExchange" th:value="${targetExchange}" />
-						<div class="form-group">
-							<label for="targetExchangeText">Target Exchange:</label>
+						<div class="form-group mb-3">
+							<label for="targetExchangeText" class="mb-2">Target Exchange:</label>
 							<input  class="form-control" id="targetExchangeText" type="text" name="targetExchangeText" th:value="${targetExchange}" disabled="disabled" />
 						</div>
-						<div class="form-group">
-							<label for="targetRoutingKeySelect">Target Routing Key:</label>
+						<div class="form-group mb-3">
+							<label for="targetRoutingKeySelect" class="mb-2">Target Routing Key:</label>
 							<select class="form-control"  id="targetRoutingKeySelect" name="targetRoutingKey">
 								<option th:each="rk : ${routingKeys}" th:value="${rk}" th:text="${rk}">	</option>
 							</select>

--- a/src/main/resources/templates/messages-move-all.html
+++ b/src/main/resources/templates/messages-move-all.html
@@ -68,5 +68,6 @@
 		</div>
 	</div>
 </div>
+<script th:src="@{/webjars/bootstrap/5.2.0/dist/js/bootstrap.min.js}"></script>
 </body>
 </html>

--- a/src/main/resources/templates/messages-move-all.html
+++ b/src/main/resources/templates/messages-move-all.html
@@ -3,7 +3,7 @@
 <head>
 	<link rel="stylesheet" th:href="@{/webjars/open-iconic/1.1.1/font/css/open-iconic-bootstrap.min.css}"/>
 	<link rel="stylesheet" th:href="@{/css/customization.css}"/>
-	<link rel="stylesheet" th:href="@{/webjars/bootstrap/4.6.0/dist/css/bootstrap.min.css}"/>
+	<link rel="stylesheet" th:href="@{/webjars/bootstrap/5.2.0/dist/css/bootstrap.min.css}"/>
 
 	<title>RabbitMQ :: Queue Management</title>
 

--- a/src/main/resources/templates/messages-move-first.html
+++ b/src/main/resources/templates/messages-move-first.html
@@ -17,11 +17,11 @@
 <div class="container main">
 	<div class="row">
 		<div class="col-12 mb-4">
-			<h1><span class="text-secondary">Queue</span>&nbsp;<span th:text="${queue}"></span><span class="text-secondary">| Virtual host</span>&nbsp;<span th:text="${vhost}"></span></h1>
+			<h1><span class="text-secondary">Queue</span>&nbsp;<span th:text="${queue}"></span><span class="text-secondary"> | Virtual host</span>&nbsp;<span th:text="${vhost}"></span></h1>
 
 			<div class="card">
 				<div class="card-body">
-					<h4 class="card-title">Move first Messages</h4>
+					<h4 class="card-title">Move first message</h4>
 
 					<div class="alert alert-danger" role="alert" th:if="${errorMessage != null}">
 						<p class="mb-0"><b><i class="oi oi-warning"></i>&nbsp;Error:</b>&nbsp;<span th:text="${errorMessage}"></span></p>
@@ -35,8 +35,8 @@
 						<input type="hidden" name="vhost" th:value="${vhost}" />
 						<input type="hidden" name="queue" th:value="${queue}" />
 						<input type="hidden" name="checksum" th:value="${checksum}" />
-						<div class="form-group">
-							<label for="targetExchangeSelect">Target Exchange:</label>
+						<div class="form-group mb-3">
+							<label for="targetExchangeSelect" class="mb-2">Target Exchange:</label>
 							<select  class="form-control" id="targetExchangeSelect" name="targetExchange">
 								<option th:each="e : ${exchanges}" th:value="${e.name}" th:text="${e.name}"></option>
 							</select>
@@ -52,12 +52,12 @@
 						<input type="hidden" name="queue" th:value="${queue}" />
 						<input type="hidden" name="checksum" th:value="${checksum}" />
 						<input type="hidden" name="targetExchange" th:value="${targetExchange}" />
-						<div class="form-group">
-							<label for="targetExchangeText">Target Exchange:</label>
+						<div class="form-group mb-3">
+							<label for="targetExchangeText" class="mb-2">Target Exchange:</label>
 							<input  class="form-control" id="targetExchangeText" type="text" name="targetExchangeText" th:value="${targetExchange}" disabled="disabled" />
 						</div>
-						<div class="form-group">
-							<label for="targetRoutingKeySelect">Target Routing Key:</label>
+						<div class="form-group mb-3">
+							<label for="targetRoutingKeySelect" class="mb-2">Target Routing Key:</label>
 							<select class="form-control"  id="targetRoutingKeySelect" name="targetRoutingKey">
 								<option th:each="rk : ${routingKeys}" th:value="${rk}" th:text="${rk}">	</option>
 							</select>

--- a/src/main/resources/templates/messages-move-first.html
+++ b/src/main/resources/templates/messages-move-first.html
@@ -3,7 +3,7 @@
 <head>
 	<link rel="stylesheet" th:href="@{/webjars/open-iconic/1.1.1/font/css/open-iconic-bootstrap.min.css}"/>
 	<link rel="stylesheet" th:href="@{/css/customization.css}"/>
-	<link rel="stylesheet" th:href="@{/webjars/bootstrap/4.6.0/dist/css/bootstrap.min.css}"/>
+	<link rel="stylesheet" th:href="@{/webjars/bootstrap/5.2.0/dist/css/bootstrap.min.css}"/>
 
 	<title>RabbitMQ :: Queue Management</title>
 

--- a/src/main/resources/templates/messages-move-first.html
+++ b/src/main/resources/templates/messages-move-first.html
@@ -72,5 +72,6 @@
 		</div>
 	</div>
 </div>
+<script th:src="@{/webjars/bootstrap/5.2.0/dist/js/bootstrap.min.js}"></script>
 </body>
 </html>

--- a/src/main/resources/templates/messages-requeue-all.html
+++ b/src/main/resources/templates/messages-requeue-all.html
@@ -48,11 +48,11 @@
 							<button type="submit" class="btn btn-primary">Yes</button>
 						</div>
 					</form>
-
 				</div>
 			</div>
 		</div>
 	</div>
 </div>
+<script th:src="@{/webjars/bootstrap/5.2.0/dist/js/bootstrap.min.js}"></script>
 </body>
 </html>

--- a/src/main/resources/templates/messages-requeue-all.html
+++ b/src/main/resources/templates/messages-requeue-all.html
@@ -3,7 +3,7 @@
 <head>
 	<link rel="stylesheet" th:href="@{/webjars/open-iconic/1.1.1/font/css/open-iconic-bootstrap.min.css}"/>
 	<link rel="stylesheet" th:href="@{/css/customization.css}"/>
-	<link rel="stylesheet" th:href="@{/webjars/bootstrap/4.6.0/dist/css/bootstrap.min.css}"/>
+	<link rel="stylesheet" th:href="@{/webjars/bootstrap/5.2.0/dist/css/bootstrap.min.css}"/>
 
 	<title>RabbitMQ :: Queue Management</title>
 

--- a/src/main/resources/templates/messages-requeue-all.html
+++ b/src/main/resources/templates/messages-requeue-all.html
@@ -17,11 +17,11 @@
 <div class="container main">
 	<div class="row">
 		<div class="col-12 mb-4">
-			<h1><span class="text-secondary">Queue</span>&nbsp;<span th:text="${queue}"></span><span class="text-secondary">| Virtual host</span>&nbsp;<span th:text="${vhost}"></span></h1>
+			<h1><span class="text-secondary">Queue</span>&nbsp;<span th:text="${queue}"></span><span class="text-secondary"> | Virtual host</span>&nbsp;<span th:text="${vhost}"></span></h1>
 
 			<div class="card">
 				<div class="card-body">
-					<h4 class="card-title">Requeue all Messages</h4>
+					<h4 class="card-title">Requeue all messages</h4>
 
 					<div class="alert alert-danger" role="alert" th:if="${errorMessage != null}">
 						<p class="mb-0"><b><i class="oi oi-warning"></i>&nbsp;Error:</b>&nbsp;<span th:text="${errorMessage}"></span></p>
@@ -29,7 +29,7 @@
 
 					<p>Requeue all message of queue <b th:text="${queue}"></b></p>
 
-					<h6>Target Routing based on First Message</h6>
+					<div class="alert alert-warning"><strong>Warning! </strong>Target routing for all is based on the first message</div>
 					<dl class="row">
 						<dt class="col-sm-6">Target Exchange</dt>
 						<dd class="col-sm-6" th:text="${targetExchange}"></dd>

--- a/src/main/resources/templates/messages-requeue-first.html
+++ b/src/main/resources/templates/messages-requeue-first.html
@@ -17,22 +17,21 @@
 <div class="container main">
 	<div class="row">
 		<div class="col-12 mb-4">
-			<h1><span class="text-secondary">Queue</span>&nbsp;<span th:text="${queue}"></span><span class="text-secondary">| Virtual host</span>&nbsp;<span th:text="${vhost}"></span></h1>
+			<h1><span class="text-secondary">Queue</span>&nbsp;<span th:text="${queue}"></span><span class="text-secondary"> | Virtual host</span>&nbsp;<span th:text="${vhost}"></span></h1>
 
 			<div class="card">
 				<div class="card-body">
-					<h4 class="card-title">Requeue first Messages</h4>
+					<h4 class="card-title">Requeue first message</h4>
 
 					<div class="alert alert-danger" role="alert" th:if="${errorMessage != null}">
 						<p class="mb-0"><b><i class="oi oi-warning"></i>&nbsp;Error:</b>&nbsp;<span th:text="${errorMessage}"></span></p>
 					</div>
 
 					<p>Requeue first message of queue <b th:text="${queue}"></b></p>
-					<p><b>Checksum:</b></p>
-					<pre th:text="${checksum}"></pre>
 
-					<h6>Target Routing:</h6>
 					<dl class="row">
+						<dt class="col-sm-6">Checksum</dt>
+						<dd class="col-sm-6" th:text="${checksum}"></dd>
 						<dt class="col-sm-6">Target Exchange</dt>
 						<dd class="col-sm-6" th:text="${targetExchange}"></dd>
 						<dt class="col-sm-6">Target Routing Key</dt>

--- a/src/main/resources/templates/messages-requeue-first.html
+++ b/src/main/resources/templates/messages-requeue-first.html
@@ -56,5 +56,6 @@
 		</div>
 	</div>
 </div>
+<script th:src="@{/webjars/bootstrap/5.2.0/dist/js/bootstrap.min.js}"></script>
 </body>
 </html>

--- a/src/main/resources/templates/messages-requeue-first.html
+++ b/src/main/resources/templates/messages-requeue-first.html
@@ -3,7 +3,7 @@
 <head>
 	<link rel="stylesheet" th:href="@{/webjars/open-iconic/1.1.1/font/css/open-iconic-bootstrap.min.css}"/>
 	<link rel="stylesheet" th:href="@{/css/customization.css}"/>
-	<link rel="stylesheet" th:href="@{/webjars/bootstrap/4.6.0/dist/css/bootstrap.min.css}"/>
+	<link rel="stylesheet" th:href="@{/webjars/bootstrap/5.2.0/dist/css/bootstrap.min.css}"/>
 
 	<title>RabbitMQ :: Queue Management</title>
 

--- a/src/main/resources/templates/messages.html
+++ b/src/main/resources/templates/messages.html
@@ -18,14 +18,14 @@
 <div class="container main">
 	<div class="row">
 		<div class="col-12 mb-4">
-			<h1><span class="text-secondary">Queue</span>&nbsp;<span th:text="${queue}"></span><span class="text-secondary">| Virtual host</span>&nbsp;<span th:text="${vhost}"></span></h1>
+			<h1><span class="text-secondary">Queue</span>&nbsp;<span th:text="${queue}"></span><span class="text-secondary"> | Virtual host</span>&nbsp;<span th:text="${vhost}"></span></h1>
 			<h2>Messages:</h2>
 			<div th:if="${#lists.isEmpty(messages)}">
 				<div class="alert alert-info" role="alert">Queue is empty</div>
 			</div>
 
 			<div class="btn-toolbar mt-2 mb-2" th:if="${not #lists.isEmpty(messages)}">
-				<div class="btn-group mr-2" role="group">
+				<div class="btn-group me-2" role="group">
 					<a th:if="${messages[0].isRequeueAllowed()}" class="btn btn-sm btn-primary" th:href="@{/messages/requeue-all(queue=${queue},vhost=${vhost})}"><span class="oi oi-loop-square" aria-hidden="true"></span>&nbsp;Requeue All</a>
 					<a class="btn btn-sm btn-primary" th:href="@{/messages/move-all(queue=${queue},vhost=${vhost})}"><span class="oi oi-share" aria-hidden="true"></span>&nbsp;Move All</a>
 				</div>
@@ -62,10 +62,14 @@
 								<div class="col-8"><pre class="mb-0"><code th:text="${m.formatBody()}">{{ renderBody(m) }}</code></pre></div>
 							</div>
 						</div>
-						<div class="btn-group float-right" role="group" th:if="${it.first}">
-							<a th:if="${m.isRequeueAllowed()}" class="btn btn-sm btn-primary" th:href="@{/messages/requeue-first(queue=${queue},vhost=${vhost},checksum=${m.checksum})}"><span class="oi oi-loop-square" aria-hidden="true"></span>&nbsp;Requeue</a>
-							<a class="btn btn-sm btn-primary" th:href="@{/messages/move-first(queue=${queue},vhost=${vhost},checksum=${m.checksum})}"><span class="oi oi-share" aria-hidden="true"></span>&nbsp;Move</a>
-							<a class="btn btn-sm btn-danger" th:href="@{/messages/delete-first(queue=${queue},vhost=${vhost},checksum=${m.checksum})}"><span class="oi oi-trash" aria-hidden="true"></span>&nbsp;Delete</a>
+						<div class="btn-toolbar float-end" role="group" th:if="${it.first}">
+							<div class="btn-group me-2">
+								<a th:if="${m.isRequeueAllowed()}" class="btn btn-sm btn-primary" th:href="@{/messages/requeue-first(queue=${queue},vhost=${vhost},checksum=${m.checksum})}"><span class="oi oi-loop-square" aria-hidden="true"></span>&nbsp;Requeue</a>
+								<a class="btn btn-sm btn-primary" th:href="@{/messages/move-first(queue=${queue},vhost=${vhost},checksum=${m.checksum})}"><span class="oi oi-share" aria-hidden="true"></span>&nbsp;Move</a>
+							</div>
+							<div class="btn-group" role="group">
+								<a class="btn btn-sm btn-danger" th:href="@{/messages/delete-first(queue=${queue},vhost=${vhost},checksum=${m.checksum})}"><span class="oi oi-trash" aria-hidden="true"></span>&nbsp;Delete</a>
+							</div>
 						</div>
 					</div>
 				</li>

--- a/src/main/resources/templates/messages.html
+++ b/src/main/resources/templates/messages.html
@@ -39,8 +39,8 @@
 					<div class="d-flex w-100 border-bottom border-info mb-1">
 						<h5 class="mb-1 flex-grow-1">Message&nbsp;<span th:text="${it.count}"></span></h5>
 						<span>
-                        <span class="badge badge-light" th:if="${m.isMoved()}"><span class="badge badge-pill badge-light border border-secondary" th:text="${m.getMovedCount() + 'x'}"></span>&nbsp;moved</span>
-                        <span class="badge badge-light" th:if="${m.isRequeued()}"><span class="badge badge-pill badge-light border border-secondary" th:text="${m.getRequeueCount() + 'x'}"></span>&nbsp;re-queued</span>
+                        <span class="badge bg-light text-dark" th:if="${m.isMoved()}"><span class="badge rounded-pill border border-secondary text-dark" th:text="${m.getMovedCount() + 'x'}"></span>&nbsp;moved</span>
+                        <span class="badge bg-light text-dark" th:if="${m.isRequeued()}"><span class="badge rounded-pill border border-secondary text-dark" th:text="${m.getRequeueCount() + 'x'}"></span>&nbsp;re-queued</span>
                     </span>
 					</div>
 					<div class="mb-1">
@@ -91,5 +91,6 @@
 	  });
 	});
 </script>
+<script th:src="@{/webjars/bootstrap/5.2.0/dist/js/bootstrap.min.js}"></script>
 </body>
 </html>

--- a/src/main/resources/templates/messages.html
+++ b/src/main/resources/templates/messages.html
@@ -3,7 +3,7 @@
 <head>
 	<link rel="stylesheet" th:href="@{/webjars/open-iconic/1.1.1/font/css/open-iconic-bootstrap.min.css}"/>
 	<link rel="stylesheet" th:href="@{/css/customization.css}"/>
-	<link rel="stylesheet" th:href="@{/webjars/bootstrap/4.6.0/dist/css/bootstrap.min.css}"/>
+	<link rel="stylesheet" th:href="@{/webjars/bootstrap/5.2.0/dist/css/bootstrap.min.css}"/>
 	<script type="text/javascript" th:src="@{/webjars/renderjson/renderjson.js}"></script>
 
 	<title>RabbitMQ :: Queue Management</title>


### PR DESCRIPTION
Closes #54.

This PR completes the migration from Bootstrap v4 to Bootstrap v5.2.0 by:
- Referencing the v5.2.0 webjar in each HTML template
- Changing to any new syntax for v5

In doing the migration, I have tried to maintain the styling as it was with Bootstrap v4 hence the introduction of two CSS classes as the base Bootstrap styles have changed.

I have also corrected some minor typos and added in a warning for when you want to re-queue all messages:
![image](https://user-images.githubusercontent.com/16258190/190921651-80dc149f-fede-41a5-8873-29ff4fcbf601.png)

Additionally, the collapse functionality is now working using the Bootstrap JS.