### PR TITLE
Fix move stuck on page when routing key is empty

### DIFF
--- a/src/main/java/de/gessnerfl/rabbitmq/queue/management/controller/MoveAllMessagesController.java
+++ b/src/main/java/de/gessnerfl/rabbitmq/queue/management/controller/MoveAllMessagesController.java
@@ -6,7 +6,6 @@ import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -48,7 +47,7 @@ public class MoveAllMessagesController {
                                   @RequestParam(name = Parameters.TARGET_ROUTING_KEY, required = false) String targetRoutingKey,
                                   Model model,
                                   RedirectAttributes redirectAttributes){
-        if(!StringUtils.hasText(targetRoutingKey)){
+        if(targetRoutingKey == null){
             return showViewWithRoutingKeysForTargetExchange(vhost, queue, targetExchange, model);
         }
 

--- a/src/main/java/de/gessnerfl/rabbitmq/queue/management/controller/MoveFirstMessageController.java
+++ b/src/main/java/de/gessnerfl/rabbitmq/queue/management/controller/MoveFirstMessageController.java
@@ -5,7 +5,6 @@ import de.gessnerfl.rabbitmq.queue.management.service.rabbitmq.RabbitMqFacade;
 import org.slf4j.Logger;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -47,7 +46,7 @@ public class MoveFirstMessageController {
                                    @RequestParam(name = Parameters.TARGET_ROUTING_KEY, required = false) String targetRoutingKey,
                                    Model model,
                                    RedirectAttributes redirectAttributes){
-        if(!StringUtils.hasText(targetRoutingKey)){
+        if(targetRoutingKey == null){
             return showViewWithRoutingKeysOfSelectedExchange(vhost, queue, checksum, targetExchange, model);
         }
 

--- a/src/test/java/de/gessnerfl/rabbitmq/queue/management/controller/MoveAllMessagesControllerTest.java
+++ b/src/test/java/de/gessnerfl/rabbitmq/queue/management/controller/MoveAllMessagesControllerTest.java
@@ -81,6 +81,26 @@ class MoveAllMessagesControllerTest {
     }
 
     @Test
+    void shouldMoveAllMessagesAndRedirectToMessagesPageWhenTargetExchangeIsProvidedAndTargetRoutingKeyIsEmpty(){
+        final String vhost = "vhost";
+        final String queue = "queue";
+        final String targetExchange = "targetExchange";
+        final String targetRoutingKey = "";
+        final Model model = mock(Model.class);
+        final RedirectAttributes redirectAttributes = mock(RedirectAttributes.class);
+
+        String result = sut.moveAllMessages(vhost, queue, targetExchange, targetRoutingKey, model, redirectAttributes);
+
+        assertEquals(Pages.MESSAGES.getRedirectString(), result);
+
+        verify(facade).moveAllMessagesInQueue(vhost, queue, targetExchange, targetRoutingKey);
+        verify(redirectAttributes).addAttribute(Parameters.VHOST, vhost);
+        verify(redirectAttributes).addAttribute(Parameters.QUEUE, queue);
+        verifyNoInteractions(model, logger);
+        verifyNoMoreInteractions(facade, redirectAttributes);
+    }
+
+    @Test
     void shouldMoveAllMessagesAndRedirectToMessagesPageWhenTargetExchangeAndRoutingKeyAreProvidedAndMoveWasSuccessful(){
         final String vhost = "vhost";
         final String queue = "queue";

--- a/src/test/java/de/gessnerfl/rabbitmq/queue/management/controller/MoveFirstMessagesControllerTest.java
+++ b/src/test/java/de/gessnerfl/rabbitmq/queue/management/controller/MoveFirstMessagesControllerTest.java
@@ -85,6 +85,27 @@ class MoveFirstMessagesControllerTest {
     }
 
     @Test
+    void shouldMoveFirstMessageAndRedirectToMessagesPageWhenTargetExchangeIsProvidedAndTargetRoutingKeyIsEmpty(){
+        final String vhost = "vhost";
+        final String queue = "queue";
+        final String checksum = "checksum";
+        final String targetExchange = "targetExchange";
+        final String targetRoutingKey = "";
+        final Model model = mock(Model.class);
+        final RedirectAttributes redirectAttributes = mock(RedirectAttributes.class);
+
+        String result = sut.moveFirstMessage(vhost, queue, checksum, targetExchange, targetRoutingKey, model, redirectAttributes);
+
+        assertEquals(Pages.MESSAGES.getRedirectString(), result);
+
+        verify(facade).moveFirstMessageInQueue(vhost, queue, checksum, targetExchange, targetRoutingKey);
+        verify(redirectAttributes).addAttribute(Parameters.VHOST, vhost);
+        verify(redirectAttributes).addAttribute(Parameters.QUEUE, queue);
+        verifyNoInteractions(model, logger);
+        verifyNoMoreInteractions(facade, redirectAttributes);
+    }
+
+    @Test
     void shouldMoveFirstMessagesAndRedirectToMessagesPageWhenTargetExchangeAndRoutingKeyAreProvidedAndMoveWasSuccessful(){
         final String vhost = "vhost";
         final String queue = "queue";


### PR DESCRIPTION
When moving messages to an exchange whose binding has an empty routing key, the routing key dropdown offers a single <option value="">. Selecting it submitted targetRoutingKey="", which the controllers treated as "not yet selected" via !StringUtils.hasText(...), so clicking Move just re-rendered Step 2 and the move never completed.