### PR TITLE
Fix move stuck on page when target exchange has no bindings

### DIFF
--- a/src/main/java/de/gessnerfl/rabbitmq/queue/management/controller/MoveAllMessagesController.java
+++ b/src/main/java/de/gessnerfl/rabbitmq/queue/management/controller/MoveAllMessagesController.java
@@ -48,9 +48,22 @@ public class MoveAllMessagesController {
                                   Model model,
                                   RedirectAttributes redirectAttributes){
         if(targetRoutingKey == null){
-            return showViewWithRoutingKeysForTargetExchange(vhost, queue, targetExchange, model);
+            List<String> routingKeys = getRoutingKeysForExchange(vhost, targetExchange);
+            if(routingKeys.isEmpty()){
+                return moveMessages(vhost, queue, targetExchange, "", model, redirectAttributes);
+            }
+            ParameterAppender.of(model)
+                    .vhost(vhost)
+                    .queue(queue)
+                    .targetExchange(targetExchange)
+                    .routingKeys(routingKeys);
+            return VIEW_NAME;
         }
 
+        return moveMessages(vhost, queue, targetExchange, targetRoutingKey, model, redirectAttributes);
+    }
+
+    private String moveMessages(String vhost, String queue, String targetExchange, String targetRoutingKey, Model model, RedirectAttributes redirectAttributes) {
         try {
             facade.moveAllMessagesInQueue(vhost, queue, targetExchange, targetRoutingKey);
             BasicRedirectAttributes.appendTo(redirectAttributes).vhost(vhost).queue(queue);
@@ -67,17 +80,11 @@ public class MoveAllMessagesController {
         }
     }
 
-    private String showViewWithRoutingKeysForTargetExchange(@RequestParam(Parameters.VHOST) String vhost, @RequestParam(Parameters.QUEUE) String queue, @RequestParam(Parameters.TARGET_EXCHANGE) String targetExchange, Model model) {
-        List<String> routingKeys = facade.getExchangeSourceBindings(vhost, targetExchange)
+    private List<String> getRoutingKeysForExchange(String vhost, String targetExchange) {
+        return facade.getExchangeSourceBindings(vhost, targetExchange)
                 .stream()
                 .map(Binding::getRoutingKey)
                 .distinct()
                 .toList();
-        ParameterAppender.of(model)
-                .vhost(vhost)
-                .queue(queue)
-                .targetExchange(targetExchange)
-                .routingKeys(routingKeys);
-        return VIEW_NAME;
     }
 }

--- a/src/main/java/de/gessnerfl/rabbitmq/queue/management/controller/MoveFirstMessageController.java
+++ b/src/main/java/de/gessnerfl/rabbitmq/queue/management/controller/MoveFirstMessageController.java
@@ -47,9 +47,23 @@ public class MoveFirstMessageController {
                                    Model model,
                                    RedirectAttributes redirectAttributes){
         if(targetRoutingKey == null){
-            return showViewWithRoutingKeysOfSelectedExchange(vhost, queue, checksum, targetExchange, model);
+            List<String> routingKeys = getRoutingKeysForExchange(vhost, targetExchange);
+            if(routingKeys.isEmpty()){
+                return moveMessage(vhost, queue, checksum, targetExchange, "", model, redirectAttributes);
+            }
+            ParameterAppender.of(model)
+                    .vhost(vhost)
+                    .queue(queue)
+                    .checksum(checksum)
+                    .targetExchange(targetExchange)
+                    .routingKeys(routingKeys);
+            return VIEW_NAME;
         }
 
+        return moveMessage(vhost, queue, checksum, targetExchange, targetRoutingKey, model, redirectAttributes);
+    }
+
+    private String moveMessage(String vhost, String queue, String checksum, String targetExchange, String targetRoutingKey, Model model, RedirectAttributes redirectAttributes) {
         try {
             facade.moveFirstMessageInQueue(vhost, queue, checksum, targetExchange, targetRoutingKey);
             BasicRedirectAttributes.appendTo(redirectAttributes).vhost(vhost).queue(queue);
@@ -67,17 +81,6 @@ public class MoveFirstMessageController {
                     .errorMessage(e.getMessage());
             return VIEW_NAME;
         }
-    }
-
-    private String showViewWithRoutingKeysOfSelectedExchange(@RequestParam(Parameters.VHOST) String vhost, @RequestParam(Parameters.QUEUE) String queue, @RequestParam(Parameters.CHECKSUM) String checksum, @RequestParam(Parameters.TARGET_EXCHANGE) String targetExchange, Model model) {
-        List<String> routingKeys = getRoutingKeysForExchange(vhost, targetExchange);
-        ParameterAppender.of(model)
-                .vhost(vhost)
-                .queue(queue)
-                .checksum(checksum)
-                .targetExchange(targetExchange)
-                .routingKeys(routingKeys);
-        return VIEW_NAME;
     }
 
     private List<String> getRoutingKeysForExchange(@RequestParam(Parameters.VHOST) String vhost, @RequestParam(Parameters.TARGET_EXCHANGE) String targetExchange) {

--- a/src/test/java/de/gessnerfl/rabbitmq/queue/management/controller/MoveAllMessagesControllerTest.java
+++ b/src/test/java/de/gessnerfl/rabbitmq/queue/management/controller/MoveAllMessagesControllerTest.java
@@ -81,6 +81,28 @@ class MoveAllMessagesControllerTest {
     }
 
     @Test
+    void shouldMoveAllMessagesImmediatelyWithEmptyRoutingKeyWhenTargetExchangeHasNoBindings(){
+        final String vhost = "vhost";
+        final String queue = "queue";
+        final String targetExchange = "targetExchange";
+        final Model model = mock(Model.class);
+        final RedirectAttributes redirectAttributes = mock(RedirectAttributes.class);
+
+        when(facade.getExchangeSourceBindings(vhost, targetExchange)).thenReturn(List.of());
+
+        String result = sut.moveAllMessages(vhost, queue, targetExchange, null, model, redirectAttributes);
+
+        assertEquals(Pages.MESSAGES.getRedirectString(), result);
+
+        verify(facade).getExchangeSourceBindings(vhost, targetExchange);
+        verify(facade).moveAllMessagesInQueue(vhost, queue, targetExchange, "");
+        verify(redirectAttributes).addAttribute(Parameters.VHOST, vhost);
+        verify(redirectAttributes).addAttribute(Parameters.QUEUE, queue);
+        verifyNoInteractions(model, logger);
+        verifyNoMoreInteractions(facade, redirectAttributes);
+    }
+
+    @Test
     void shouldMoveAllMessagesAndRedirectToMessagesPageWhenTargetExchangeIsProvidedAndTargetRoutingKeyIsEmpty(){
         final String vhost = "vhost";
         final String queue = "queue";

--- a/src/test/java/de/gessnerfl/rabbitmq/queue/management/controller/MoveFirstMessagesControllerTest.java
+++ b/src/test/java/de/gessnerfl/rabbitmq/queue/management/controller/MoveFirstMessagesControllerTest.java
@@ -85,6 +85,29 @@ class MoveFirstMessagesControllerTest {
     }
 
     @Test
+    void shouldMoveFirstMessageImmediatelyWithEmptyRoutingKeyWhenTargetExchangeHasNoBindings(){
+        final String vhost = "vhost";
+        final String queue = "queue";
+        final String checksum = "checksum";
+        final String targetExchange = "targetExchange";
+        final Model model = mock(Model.class);
+        final RedirectAttributes redirectAttributes = mock(RedirectAttributes.class);
+
+        when(facade.getExchangeSourceBindings(vhost, targetExchange)).thenReturn(List.of());
+
+        String result = sut.moveFirstMessage(vhost, queue, checksum, targetExchange, null, model, redirectAttributes);
+
+        assertEquals(Pages.MESSAGES.getRedirectString(), result);
+
+        verify(facade).getExchangeSourceBindings(vhost, targetExchange);
+        verify(facade).moveFirstMessageInQueue(vhost, queue, checksum, targetExchange, "");
+        verify(redirectAttributes).addAttribute(Parameters.VHOST, vhost);
+        verify(redirectAttributes).addAttribute(Parameters.QUEUE, queue);
+        verifyNoInteractions(model, logger);
+        verifyNoMoreInteractions(facade, redirectAttributes);
+    }
+
+    @Test
     void shouldMoveFirstMessageAndRedirectToMessagesPageWhenTargetExchangeIsProvidedAndTargetRoutingKeyIsEmpty(){
         final String vhost = "vhost";
         final String queue = "queue";


### PR DESCRIPTION
When the target exchange has no bindings, skip Step 2 and move immediately with an empty routing key instead of waiting for a selection that can't exist.